### PR TITLE
AB#140285 Remove keep_backup option from refresh API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -616,17 +616,6 @@ curl -XDELETE "http://{flex}/api/echo/v1/echo_dbs" -H 'Content-Type: application
 This api will replace underline volumes of the selected databases with an new volumes.
 The new volumes are cloned from a desired snapshot.
 
-In case of keep_backup is true. The original database is renamed to a new name
-
-```
-<db_name>_bkp_<timestamp>
-```
-
-db_name: is an original db name
-timestamp: The time of the refresh. The timestamp is in ISO 8601 format. "20250216T143521Z"
-
-fin-db => fin-db_bkp_20250216T143521Z
-
 ### Endpoint:
 
 `POST /api/echo/v1/hosts/{host_id}/databases/_refresh`
@@ -643,7 +632,6 @@ fin-db => fin-db_bkp_20250216T143521Z
   "db_names": [
     "string"
   ],
-  "keep_backup": true,
   "target_state": "online"
 }
 ```
@@ -659,8 +647,6 @@ fin-db => fin-db_bkp_20250216T143521Z
 
 - `snapshot_id` (string, required): The unique identifier for the database snapshot.
 - `db_names` (array of strings, required): The names of the databases on the host to be replaced.
-- `keep_backup` (boolean, optional): If set to true, Flex will rename the original db to `{name}_bkp_{timestamp}` instead of deletion. Default: `false`.
-  - Note: Requires special permissions on the host.
 - `target_state` (string, optional): The target state for the refreshed database. Default: `"online"`.
   - Possible values: `recovery`, `online`
 
@@ -669,7 +655,7 @@ fin-db => fin-db_bkp_20250216T143521Z
 ```bash
 curl -XPOST "http://{flex}/api/echo/v1/hosts/{host_id}/databases/_refresh" \
 -H "Authorization: Bearer {token}" \
--d'{"snapshot_id":"snap_1735025906","db_names": ["dev_db","dev_db2"],"keep_backup":true}'
+-d'{"snapshot_id":"snap_1735025906","db_names": ["dev_db","dev_db2"]}'
 ```
 
 #### Responses:

--- a/example/powershell/refresh_echo_db.ps1
+++ b/example/powershell/refresh_echo_db.ps1
@@ -748,7 +748,6 @@ function Invoke-DatabaseRefresh {
     $replaceBody = @{
         snapshot_id = $SnapshotId
         db_names    = $EchoDbNames
-        keep_backup = $false
     }
 
     $replaceEndpoint = "/api/echo/v1/hosts/$($EchoHost.host.id)/databases/_refresh"

--- a/example/python/coverage/test_refresh_database.py
+++ b/example/python/coverage/test_refresh_database.py
@@ -152,7 +152,6 @@ def run(
         refresh_payload = {
             "snapshot_id": snapshot_id2,
             "db_names": [echo_db_name],
-            "keep_backup": False,
         }
 
         # Test direct endpoint

--- a/example/python/refresh.py
+++ b/example/python/refresh.py
@@ -65,7 +65,6 @@ def _tracking_id():
 def _make_refresh(
     host_id: str,
     db_names: tuple[str],
-    keep_backup: bool,
     snapshot_id: str,
 ) -> Tuple[bool, dict]:
 
@@ -81,7 +80,6 @@ def _make_refresh(
     }
     post_data = {
         "db_names": db_names,
-        "keep_backup": keep_backup,
         "snapshot_id": snapshot_id,
     }
     print(f"Making refresh request with tracking ID: {tracking_id}, data: {post_data}")
@@ -145,7 +143,6 @@ def _wait_for_task(task: dict) -> tuple[bool, dict]:
 def run(
     host_id: str,
     db_names: tuple[str],
-    keep_backup: bool,
     snapshot_id: str,
 ):
     """This script refreshes a databases on host from a snapshot.
@@ -156,12 +153,11 @@ def run(
        - `FLEX_TOKEN`: Bearer token for Flex API authentication.
        - `FLEX_IP`: Flex server IP address.
 
-    python refresh.py --host-name <host-name> --db-names <db-name-1,db-name-2> --keep-backup --snapshot-id <snapshot-id>
+    python refresh.py --host-name <host-name> --db-names <db-name-1,db-name-2> --snapshot-id <snapshot-id>
 
     Args:
         host_id (str): Host id to take snapshot from
         db_names (list[str]): List of database names to refresh
-        keep_backup (bool): Keep backup of the current databases by renaming them
         snapshot_id (str): Snapshot id to refresh from
     """
 
@@ -172,7 +168,7 @@ def run(
     _go_no_go(msg="Do you want to continue?")
 
     print(f"refreshing")
-    success, task = _make_refresh(host_id, db_names, keep_backup, snapshot_id)
+    success, task = _make_refresh(host_id, db_names, snapshot_id)
     if not success:
         exit_with_error(f"Failed to refresh databases. Error: {task['error']}")
     else:
@@ -205,13 +201,6 @@ def parse_arguments():
         metavar="DB_NAMES",
     )
     parser.add_option(
-        "--keep-backup",
-        dest="keep_backup",
-        action="store_true",
-        default=False,
-        help="Keep backup of the current databases by renaming them",
-    )
-    parser.add_option(
         "--snapshot-id",
         dest="snapshot_id",
         help="Snapshot id to refresh from",
@@ -233,7 +222,6 @@ def parse_arguments():
     return {
         "host_id": options.host_id,
         "db_names": db_names,
-        "keep_backup": options.keep_backup,
         "snapshot_id": options.snapshot_id,
     }
 


### PR DESCRIPTION
## Summary
- Remove `keep_backup` parameter from API documentation, examples, and tests
- Companion PR to healthshield #9167 which removes the option from the backend

## Changed files
- `README.md` — removed keep_backup from request body, parameters, and curl example
- `example/python/refresh.py` — removed keep_backup argument and CLI option
- `example/powershell/refresh_echo_db.ps1` — removed keep_backup from request body
- `example/python/coverage/test_refresh_database.py` — removed keep_backup from test payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)